### PR TITLE
Add a Nix flake and installation instruction with Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+### Nix ###
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -142,8 +142,11 @@ sudo apt update && sudo apt install jarmemu
 
 ## Nix
 
+[![NixOS](https://img.shields.io/badge/Nix-5277C3?style=for-the-badge&logo=nixos&logoColor=white)](#nix)
+[![NixOS](https://img.shields.io/badge/NixOS-FFFFF3?style=for-the-badge&logo=nixos&logoColor=5277C3)](#nix)
+
 <img src="https://static.dwightstudio.fr/jarmemu/LOGO_MONO.svg" alt="drawing" width="15"/> JArmEmu is available with the [Nix](https://nixos.org/) package manager through this repository flake.
-You can build/run it imperatively bu running (with flake enabled):
+You can build/run it imperatively by running (with flake enabled):
 
 ```bash
 nix build github:Dwight-Studio/jArmEmu

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - [Fedora/Nobara](#fedora)
   - [Arch Linux/Manjaro](#arch-linux)
   - [Debian/Ubuntu/Pop! OS/Linux Mint/Kali Linux](#debian)
+  - [Nix](#nix)
 - [Licence](#licence)
 
 # Features
@@ -138,6 +139,18 @@ You can install it by running:
 sudo wget -O - https://deb.dwightstudio.fr/install-repository.sh | sudo bash
 sudo apt update && sudo apt install jarmemu
 ```
+
+## Nix
+
+<img src="https://static.dwightstudio.fr/jarmemu/LOGO_MONO.svg" alt="drawing" width="15"/> JArmEmu is available with the [Nix](https://nixos.org/) package manager through this repository flake.
+You can build/run it imperatively bu running (with flake enabled):
+
+```bash
+nix build github:Dwight-Studio/jArmEmu
+nix run github:Dwight-Studio/jArmEmu
+```
+
+Otherwise, use your preferred way to declaratively install the package `jarmemu` from the `github:Dwight-Studio/jArmEmu` flake as input.
 
 ## Licence
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,39 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
+        "path": "/nix/store/m1szqwijms610n6325mwjswslha4nd92-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  description = "Simple ARMv7 simulator written in Java, intended for educational purpose";
+
+  inputs.nixpkgs.url = "nixpkgs";
+  inputs.systems.url = "github:nix-systems/default";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+    }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+      pkgsFor = eachSystem (system: import nixpkgs { localSystem = system; });
+    in
+    {
+      packages = eachSystem (system: {
+        default = self.packages.${system}.jarmemu;
+        jarmemu = pkgsFor.${system}.callPackage (
+          {
+            lib,
+            maven,
+            jre,
+            makeWrapper,
+            wrapGAppsHook,
+            extraJavaOpts ? [ ],
+          }:
+          let
+            baseJavaOpts = [
+              "-Dprism.dirtyopts=false"
+              "--add-exports=javafx.base/com.sun.javafx.collections=ALL-UNNAMED"
+              "--add-exports=javafx.graphics/com.sun.javafx.application=ALL-UNNAMED"
+            ];
+          in
+          maven.buildMavenPackage {
+            pname = "jArmEmu";
+            version = "1.1.0";
+
+            src = self;
+
+            mvnHash = "sha256-0AU6XTsTpalWlfWpOdcn6D+fDfC6GlliCoYXVqnOH9M=";
+
+            nativeBuildInputs = [
+              makeWrapper
+              wrapGAppsHook
+            ];
+
+            installPhase = ''
+              runHook preInstall
+
+              cd jarmemu-distribution/target/jarmemu
+
+              install -d $out/share/java/jarmemu/
+              install -Dm644 *.jar $out/share/java/jarmemu/
+              install -Dm644 lib/* -t $out/share/java/jarmemu/lib/
+
+              makeWrapper ${jre}/bin/java $out/bin/jarmemu \
+                --set _JAVA_OPTIONS "${toString (baseJavaOpts ++ extraJavaOpts)}" \
+                --add-flags "-jar $out/share/java/jarmemu/jarmemu-launcher.jar"
+
+              install -Dm644 resources/icons/hicolor/scalable/apps/fr.dwightstudio.JArmEmu.svg \
+                $out/share/icons/hicolor/scalable/apps/fr.dwightstudio.JArmEmu.svg
+              install -Dm 644 resources/mime/packages/fr.dwightstudio.JArmEmu.xml \
+                $out/share/mime/packages/fr.dwightstudio.JArmEmu.xml
+              install -Dm 644 resources/metainfo/fr.dwightstudio.JArmEmu.metainfo.xml \
+                $out/share/metainfo/fr.dwightstudio.JArmEmu.metainfo.xml
+              install -Dm644 resources/fr.dwightstudio.JArmEmu.desktop \
+                $out/share/applications/fr.dwightstudio.JArmEmu.desktop
+
+              runHook postInstall
+            '';
+
+            meta = with lib; {
+              description = "Simple ARMv7 simulator written in Java, intended for educational purpose";
+              homepage = "https://www.dwightstudio.fr/projects/JArmEmu";
+              mainProgram = "jarmemu";
+              license = licenses.gpl3Only;
+            };
+          }
+        ) { jre = pkgsFor.${system}.jre.override { enableJavaFX = true; }; };
+      });
+
+      formatter = eachSystem (system: pkgsFor.${system}.nixfmt-rfc-style);
+    };
+}


### PR DESCRIPTION
This PR adds a "Nix flake" to the repository which allows one to build/install/work on the project with the [Nix](https://nixos.org/) package manager.

There are two main (non-exclusive) ways to make a package installable for anyone with Nix:
1) add the package definition to a package set (e.g., [nixpkgs](https://github.com/nixos/nixpkgs))
2) add the package definition to the repository itself, which is less discoverable but easier to maintain/update especially in the early developments.

I've chosen the second way if you are OK with it.

To update the package definition, if there are no breaking changes (like adding a new dependency or changing the installation procedure), simply do:
1) change the `version` string
2) run `nix flake update` to update the flake inputs (like the `nixpkgs` package set)
3) update the hash in `mvnHash` (this hash changes if the Maven dependencies change) using TOFU method:
    1. remove the hash value (use empty string `""`)
    2. run `nix build`, let Nix complain and copy the given hash
4) run `nix build` again and test (e.g., `nix run`)