### PR TITLE
Updating from v1.1.3 to v1.1.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.1.3 -> 1.1.4
+
+- Nothing (yet!)
+
 1.1.2 -> 1.1.3
 
 - Improved autocompletion of braces and brackets (resolved #27)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 1.1.3 -> 1.1.4
 
-- Nothing (yet!)
+- Fixed pc behaviour when pc is the register destination (resolved #34)
 
 1.1.2 -> 1.1.3
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           in
           maven.buildMavenPackage {
             pname = "jArmEmu";
-            version = "1.1.2";
+            version = "1.1.3";
 
             src = self;
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           in
           maven.buildMavenPackage {
             pname = "jArmEmu";
-            version = "1.1.3";
+            version = "1.1.4";
 
             src = self;
 

--- a/jarmemu-base/pom.xml
+++ b/jarmemu-base/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.4</version>
     </parent>
 
     <name>Base</name>

--- a/jarmemu-base/pom.xml
+++ b/jarmemu-base/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
     </parent>
 
     <name>Base</name>

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/AddressArgument.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/AddressArgument.java
@@ -231,7 +231,7 @@ public class AddressArgument extends ParsedArgument<AddressArgument.UpdatableInt
             this.register = register;
             this.update = update;
 
-            originalValue = register.getData();
+            originalValue = register != null ? register.getData() : 0;
             if (updateNow) register.setData(integer);
         }
 

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/LabelOrRegisterArgument.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/LabelOrRegisterArgument.java
@@ -30,7 +30,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 
 import java.util.function.Supplier;
 
-public class LabelOrRegisterArgument extends ParsedArgument<Integer> {
+public class LabelOrRegisterArgument extends ParsedArgument<Integer> implements OptionalRegister {
 
     private RegisterArgument register;
     private LabelArgument label;

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/RegisterArgument.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/RegisterArgument.java
@@ -33,7 +33,7 @@ import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 
 import java.util.function.Supplier;
 
-public class RegisterArgument extends ParsedArgument<Register> {
+public class RegisterArgument extends ParsedArgument<Register> implements OptionalRegister {
     
     private final RegisterUtils register;
 

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/RegisterWithUpdateArgument.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/RegisterWithUpdateArgument.java
@@ -30,6 +30,7 @@ import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
 import fr.dwightstudio.jarmemu.base.gui.JArmEmuApplication;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 import fr.dwightstudio.jarmemu.base.sim.entity.UpdatableRegister;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 
 import java.util.function.Supplier;
 
@@ -68,6 +69,8 @@ public class RegisterWithUpdateArgument extends ParsedArgument<UpdatableRegister
     @Override
     public void verify(Supplier<StateContainer> stateSupplier) throws ASMException {
         argument.verify(stateSupplier);
+
+        if (argument.getRegisterNumber() == RegisterUtils.PC.getN()) throw new SyntaxASMException(JArmEmuApplication.formatMessage("%exception.argument.invalidRegister", "PC"));
 
         super.verify(stateSupplier);
     }

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/RegisterWithUpdateArgument.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/argument/RegisterWithUpdateArgument.java
@@ -33,7 +33,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.UpdatableRegister;
 
 import java.util.function.Supplier;
 
-public class RegisterWithUpdateArgument extends ParsedArgument<UpdatableRegister> {
+public class RegisterWithUpdateArgument extends ParsedArgument<UpdatableRegister> implements OptionalRegister {
 
     boolean update;
     RegisterArgument argument;

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ADCInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ADCInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -39,6 +36,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 import fr.dwightstudio.jarmemu.base.util.MathUtils;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -83,7 +81,7 @@ public class ADCInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ADDInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ADDInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -39,6 +36,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 import fr.dwightstudio.jarmemu.base.util.MathUtils;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -83,7 +81,7 @@ public class ADDInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ADRInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ADRInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.LabelArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.NullArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -37,6 +34,7 @@ import fr.dwightstudio.jarmemu.base.asm.modifier.UpdateFlags;
 import fr.dwightstudio.jarmemu.base.gui.JArmEmuApplication;
 import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -81,7 +79,7 @@ public class ADRInstruction extends ParsedInstruction<Register, Integer, Object,
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ANDInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ANDInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -38,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -82,7 +80,7 @@ public class ANDInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ASRInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ASRInstruction.java
@@ -35,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.gui.JArmEmuApplication;
 import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -79,7 +80,7 @@ public class ASRInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN()) && !((ImmediateOrRegisterArgument) arg3).isRegister();
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/BICInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/BICInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -38,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -82,7 +80,7 @@ public class BICInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/EORInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/EORInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -38,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -82,7 +80,7 @@ public class EORInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/LDMInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/LDMInstruction.java
@@ -38,6 +38,7 @@ import fr.dwightstudio.jarmemu.base.asm.modifier.UpdateMode;
 import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 import fr.dwightstudio.jarmemu.base.sim.entity.UpdatableRegister;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -82,7 +83,7 @@ public class LDMInstruction extends ParsedInstruction<UpdatableRegister, Registe
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return (((RegisterArrayArgument) arg2).getArguments()).stream().anyMatch(arg -> arg.getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/LDRInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/LDRInstruction.java
@@ -37,8 +37,10 @@ import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -87,7 +89,7 @@ public class LDRInstruction extends ParsedInstruction<Register, AddressArgument.
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/LSLInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/LSLInstruction.java
@@ -35,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.gui.JArmEmuApplication;
 import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -79,7 +80,7 @@ public class LSLInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN()) && !((ImmediateOrRegisterArgument) arg3).isRegister();
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/LSRInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/LSRInstruction.java
@@ -35,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.gui.JArmEmuApplication;
 import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -79,7 +80,7 @@ public class LSRInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN()) && !((ImmediateOrRegisterArgument) arg3).isRegister();
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/MOVInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/MOVInstruction.java
@@ -37,6 +37,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -85,7 +86,7 @@ public class MOVInstruction extends ParsedInstruction<Register, RegisterOrImmedi
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/MVNInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/MVNInstruction.java
@@ -35,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -79,7 +80,7 @@ public class MVNInstruction extends ParsedInstruction<Register, RegisterOrImmedi
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ORRInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/ORRInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -38,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -82,7 +80,7 @@ public class ORRInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/POPInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/POPInstruction.java
@@ -35,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.asm.modifier.ModifierParameter;
 import fr.dwightstudio.jarmemu.base.asm.modifier.UpdateMode;
 import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -90,7 +91,7 @@ public class POPInstruction extends ParsedInstruction<Register[], Object, Object
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return (((RegisterArrayArgument) arg1).getArguments()).stream().anyMatch(arg -> arg.getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/RORInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/RORInstruction.java
@@ -35,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.gui.JArmEmuApplication;
 import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -79,7 +80,7 @@ public class RORInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN()) && !((ImmediateOrRegisterArgument) arg3).isRegister();
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/RRXInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/RRXInstruction.java
@@ -24,6 +24,7 @@
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
 import fr.dwightstudio.jarmemu.base.asm.argument.NullArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.OptionalRegister;
 import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
 import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
@@ -34,6 +35,7 @@ import fr.dwightstudio.jarmemu.base.asm.modifier.ModifierParameter;
 import fr.dwightstudio.jarmemu.base.asm.modifier.UpdateFlags;
 import fr.dwightstudio.jarmemu.base.sim.entity.Register;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -78,7 +80,7 @@ public class RRXInstruction extends ParsedInstruction<Register, Register, Object
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/RSBInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/RSBInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -39,6 +36,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 import fr.dwightstudio.jarmemu.base.util.MathUtils;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -83,7 +81,7 @@ public class RSBInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/RSCInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/RSCInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -39,6 +36,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 import fr.dwightstudio.jarmemu.base.util.MathUtils;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -83,7 +81,7 @@ public class RSCInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/SBCInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/SBCInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -39,6 +36,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 import fr.dwightstudio.jarmemu.base.util.MathUtils;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -83,7 +81,7 @@ public class SBCInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/SUBInstruction.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/asm/instruction/SUBInstruction.java
@@ -23,10 +23,7 @@
 
 package fr.dwightstudio.jarmemu.base.asm.instruction;
 
-import fr.dwightstudio.jarmemu.base.asm.argument.ParsedArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.RotatedImmediateOrRegisterArgument;
-import fr.dwightstudio.jarmemu.base.asm.argument.ShiftArgument;
+import fr.dwightstudio.jarmemu.base.asm.argument.*;
 import fr.dwightstudio.jarmemu.base.asm.exception.ASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.ExecutionASMException;
 import fr.dwightstudio.jarmemu.base.asm.exception.SyntaxASMException;
@@ -39,6 +36,7 @@ import fr.dwightstudio.jarmemu.base.sim.entity.RegisterOrImmediate;
 import fr.dwightstudio.jarmemu.base.sim.entity.ShiftFunction;
 import fr.dwightstudio.jarmemu.base.sim.entity.StateContainer;
 import fr.dwightstudio.jarmemu.base.util.MathUtils;
+import fr.dwightstudio.jarmemu.base.util.RegisterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -83,7 +81,7 @@ public class SUBInstruction extends ParsedInstruction<Register, Register, Regist
 
     @Override
     public boolean doModifyPC() {
-        return false;
+        return !modifier.doUpdateFlags() && (((OptionalRegister) arg1).getRegisterNumber() == RegisterUtils.PC.getN());
     }
 
     @Override

--- a/jarmemu-distribution/pom.xml
+++ b/jarmemu-distribution/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
     </parent>
 
     <name>Distribution</name>

--- a/jarmemu-distribution/pom.xml
+++ b/jarmemu-distribution/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.4</version>
     </parent>
 
     <name>Distribution</name>

--- a/jarmemu-launcher/pom.xml
+++ b/jarmemu-launcher/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
     </parent>
 
     <name>Launcher</name>

--- a/jarmemu-launcher/pom.xml
+++ b/jarmemu-launcher/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.4</version>
     </parent>
 
     <name>Launcher</name>

--- a/jarmemu-medias/pom.xml
+++ b/jarmemu-medias/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.4</version>
     </parent>
 
     <name>Medias</name>

--- a/jarmemu-medias/pom.xml
+++ b/jarmemu-medias/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
     </parent>
 
     <name>Medias</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <name>JArmEmu</name>
     <groupId>fr.dwightstudio.jarmemu</groupId>
     <artifactId>jarmemu</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <name>JArmEmu</name>
     <groupId>fr.dwightstudio.jarmemu</groupId>
     <artifactId>jarmemu</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/resources/metainfo/fr.dwightstudio.JArmEmu.metainfo.xml
+++ b/resources/metainfo/fr.dwightstudio.JArmEmu.metainfo.xml
@@ -77,6 +77,17 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release date="2024-11-02" version="1.1.4">
+            <url type="details">https://github.com/Dwight-Studio/JArmEmu/releases/tag/v1.1.4</url>
+            <description>
+                <p>Stable release of JArmEmu</p>
+                <p>Changelog:</p>
+                <ul>
+                    <li>Fixed pc behaviour when pc is the register destination (resolved #34)</li>
+                    <li>Fixed LDM/STM throwing exception when update mode is not specified (resolved #35)</li>
+                </ul>
+            </description>
+        </release>
         <release date="2024-11-02" version="1.1.3">
             <url type="details">https://github.com/Dwight-Studio/JArmEmu/releases/tag/v1.1.3</url>
             <description>

--- a/resources/metainfo/fr.dwightstudio.JArmEmu.metainfo.xml
+++ b/resources/metainfo/fr.dwightstudio.JArmEmu.metainfo.xml
@@ -77,6 +77,21 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release date="2024-11-02" version="1.1.3">
+            <url type="details">https://github.com/Dwight-Studio/JArmEmu/releases/tag/v1.1.3</url>
+            <description>
+                <p>Stable release of JArmEmu</p>
+                <p>Changelog:</p>
+                <ul>
+                    <li>Improved autocompletion of braces and brackets (resolved #27)</li>
+                    <li>Added shortcut to comment all selected lines (resolved #29)</li>
+                    <li>Fixed autocompletion behaviour when declaring label with space (resolved #26)</li>
+                    <li>Fixed simulation button being re-enabled when you save while simulating (resolved #28)</li>
+                    <li>Fixed double EOF notification when the last instruction is forced</li>
+                    <li>Fixed double indexing on LDR/STR instructions when forced (resolved #32)</li>
+                </ul>
+            </description>
+        </release>
         <release date="2024-10-17" version="1.1.2">
             <url type="details">https://github.com/Dwight-Studio/JArmEmu/releases/tag/v1.1.2</url>
             <description>


### PR DESCRIPTION
Updating from v1.1.3 to v1.1.4

- Fixed pc behaviour when pc is the register destination (resolved #34)
- Fixed LDM/STM throwing exception when update mode is not specified (resolved #35)