### PR TITLE
Updating from v1.1.4 to v1.1.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+1.1.4 -> 1.1.5
+
+- Fixed vulnerability to CVE-2025-48924 (commons-lang3)
+- Fixed vulnerability to CVE-2024-47554 (github-api/commons-io)
+- Fixed vulnerability to CVE-2024-20925 (javafx-graphics)
+- Fixed static assets URLs (resolved #40)
+
+
 1.1.3 -> 1.1.4
 
 - Fixed pc behaviour when pc is the register destination (resolved #34)

--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
-        "path": "/nix/store/m1szqwijms610n6325mwjswslha4nd92-source",
-        "type": "path"
+        "lastModified": 1760596604,
+        "narHash": "sha256-J/i5K6AAz/y5dBePHQOuzC7MbhyTOKsd/GLezSbEFiM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3cbe716e2346710d6e1f7c559363d14e11c32a43",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -35,11 +35,11 @@
           in
           maven.buildMavenPackage {
             pname = "jArmEmu";
-            version = "1.1.4";
+            version = "1.1.5";
 
             src = self;
 
-            mvnHash = "sha256-0AU6XTsTpalWlfWpOdcn6D+fDfC6GlliCoYXVqnOH9M=";
+            mvnHash = "sha256-sXvKm/1h2YlTo3eSyz+mj36Po6nQQuMUkrwNUI6RIkI=";
 
             nativeBuildInputs = [
               makeWrapper

--- a/jarmemu-base/pom.xml
+++ b/jarmemu-base/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <name>Base</name>

--- a/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/gui/JArmEmuApplication.java
+++ b/jarmemu-base/src/main/java/fr/dwightstudio/jarmemu/base/gui/JArmEmuApplication.java
@@ -136,6 +136,9 @@ public class JArmEmuApplication extends Application {
         launch(args);
     }
 
+    // Urgent
+    // TODO: Move the SHOWCASE in static
+
     // Soon:
     // TODO: Add newbies hints (for the breakpoints, stack, double click on symbols...)
 

--- a/jarmemu-distribution/pom.xml
+++ b/jarmemu-distribution/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <name>Distribution</name>

--- a/jarmemu-launcher/pom.xml
+++ b/jarmemu-launcher/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <name>Launcher</name>

--- a/jarmemu-medias/pom.xml
+++ b/jarmemu-medias/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>fr.dwightstudio.jarmemu</groupId>
         <artifactId>jarmemu</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.5</version>
     </parent>
 
     <name>Medias</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <name>JArmEmu</name>
     <groupId>fr.dwightstudio.jarmemu</groupId>
     <artifactId>jarmemu</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -57,25 +57,25 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>linux</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>linux</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>linux</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>linux</classifier>
         </dependency>
 
@@ -83,25 +83,25 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>win</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>win</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>win</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>win</classifier>
         </dependency>
 
@@ -109,25 +109,25 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>mac</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>mac</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>mac</classifier>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>21</version>
+            <version>21.0.2</version>
             <classifier>mac</classifier>
         </dependency>
 
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.13.0</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.fxmisc.richtext</groupId>
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.321</version>
+            <version>1.330</version>
         </dependency>
     </dependencies>
 

--- a/resources/metainfo/fr.dwightstudio.JArmEmu.metainfo.xml
+++ b/resources/metainfo/fr.dwightstudio.JArmEmu.metainfo.xml
@@ -53,30 +53,43 @@
     <screenshots>
         <screenshot type="default">
             <caption>Editor: Primer Dark theme</caption>
-            <image type="source">https://static.dwightstudio.fr/jarmemu/PNG/SHOWCASE/PRIMER_DARK.png</image>
+            <image type="source">https://static.dwightstudio.fr/v1/jarmemu/showcase/primer_dark.png</image>
         </screenshot>
         <screenshot type="extra">
             <caption>Editor: Primer Light theme</caption>
-            <image type="source">https://static.dwightstudio.fr/jarmemu/PNG/SHOWCASE/PRIMER_LIGHT.png</image>
+            <image type="source">https://static.dwightstudio.fr/v1/jarmemu/showcase/primer_light.png</image>
         </screenshot>
         <screenshot type="extra">
             <caption>Editor: Nord Dark theme</caption>
-            <image type="source">https://static.dwightstudio.fr/jarmemu/PNG/SHOWCASE/NORD_DARK.png</image>
+            <image type="source">https://static.dwightstudio.fr/v1/jarmemu/showcase/nord_dark.png</image>
         </screenshot>
         <screenshot type="extra">
             <caption>Editor: Nord Light theme</caption>
-            <image type="source">https://static.dwightstudio.fr/jarmemu/PNG/SHOWCASE/NORD_LIGHT.png</image>
+            <image type="source">https://static.dwightstudio.fr/v1/jarmemu/showcase/nord_light.png</image>
         </screenshot>
         <screenshot type="extra">
             <caption>Editor: Cupertino Dark theme</caption>
-            <image type="source">https://static.dwightstudio.fr/jarmemu/PNG/SHOWCASE/CUPERTINO_DARK.png</image>
+            <image type="source">https://static.dwightstudio.fr/v1/jarmemu/showcase/cupertino_dark.png</image>
         </screenshot>
         <screenshot type="extra">
             <caption>Editor: Cupertino Light theme</caption>
-            <image type="source">https://static.dwightstudio.fr/jarmemu/PNG/SHOWCASE/CUPERTINO_LIGHT.png</image>
+            <image type="source">https://static.dwightstudio.fr/v1/jarmemu/showcase/cupertino_light.png</image>
         </screenshot>
     </screenshots>
     <releases>
+        <release date="2025-10-18" version="1.1.5">
+            <url type="details">https://github.com/Dwight-Studio/JArmEmu/releases/tag/v1.1.5</url>
+            <description>
+                <p>Stable release of JArmEmu</p>
+                <p>Changelog:</p>
+                <ul>
+                    <li>Fixed vulnerability to CVE-2025-48924 (commons-lang3)</li>
+                    <li>Fixed vulnerability to CVE-2024-47554 (github-api/commons-io)</li>
+                    <li>Fixed vulnerability to CVE-2024-20925 (javafx-graphics)</li>
+                    <li>Fixed static assets URLs (resolved #40)</li>
+                </ul>
+            </description>
+        </release>
         <release date="2025-02-15" version="1.1.4">
             <url type="details">https://github.com/Dwight-Studio/JArmEmu/releases/tag/v1.1.4</url>
             <description>


### PR DESCRIPTION
Updating from v1.1.3 to v1.1.4
- Fixed vulnerability to CVE-2025-48924 (commons-lang3)
- Fixed vulnerability to CVE-2024-47554 (github-api/commons-io)
- Fixed vulnerability to CVE-2024-20925 (javafx-graphics)
- Fixed static assets URLs (resolved #40)